### PR TITLE
chore: abstract out query, use struct of query return better

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -126,13 +126,7 @@ class Genesis {
      * Persistent storage for settings
      * @type {Database}
      */
-    this.settings = new Database({
-      host: process.env.MYSQL_HOST || 'localhost',
-      port: process.env.MYSQL_PORT || 3306,
-      user: process.env.MYSQL_USER || 'genesis',
-      password: process.env.MYSQL_PASSWORD,
-      database: process.env.MYSQL_DB || 'genesis',
-    }, this);
+    this.settings = new Database(this);
 
     /**
      * Objects holding worldState data, one for each platform

--- a/src/eventHandlers/ReadyRatioCheck.js
+++ b/src/eventHandlers/ReadyRatioCheck.js
@@ -47,7 +47,7 @@ async function guildLeave(self) {
       });
     });
     if ((results.length - 5) <= 0) {
-      self.logger.debug('No more guilds in "guild_ratio" clearing interval.');
+      self.logger.silly('No more guilds in "guild_ratio" clearing interval.');
       clearInterval(guildCheck);
     }
   } catch (e) {
@@ -61,7 +61,7 @@ async function guildLeave(self) {
  */
 function guildRatioCheck(self) {
   const guilds = self.client.guilds.cache.filter((guild) => {
-    self.logger.debug(`Checking Guild: ${guild.name} (${guild.id}) Owner: ${guild.ownerID}`);
+    self.logger.silly(`Checking Guild: ${guild.name} (${guild.id}) Owner: ${guild.ownerID}`);
     const bots = guild.members.cache.filter(user => user.user.bot);
     return ((bots.size / guild.memberCount) * 100) >= 80;
   });

--- a/src/notifications/NotifierUtils.js
+++ b/src/notifications/NotifierUtils.js
@@ -23,14 +23,6 @@ const embeds = {
   Outposts: require('../embeds/SentientOutpostEmbed'),
 };
 
-// const dbSettings = {
-//   host: process.env.MYSQL_HOST || 'localhost',
-//   port: process.env.MYSQL_PORT || 3306,
-//   user: process.env.MYSQL_USER || 'genesis',
-//   password: process.env.MYSQL_PASSWORD,
-//   database: process.env.MYSQL_DB || 'genesis',
-// };
-
 const { Rest } = require('@spectacles/rest');
 
 const rest = new Rest(process.env.TOKEN);
@@ -38,7 +30,7 @@ const rest = new Rest(process.env.TOKEN);
 const logger = require('../Logger');
 
 // const Database = require('../settings/Database');
-// const db = new Database(dbSettings);
+// const db = new Database();
 
 module.exports = {
   rest,

--- a/src/settings/DatabaseQueries/BlacklistQueries.js
+++ b/src/settings/DatabaseQueries/BlacklistQueries.js
@@ -11,9 +11,9 @@ class BlacklistQueries {
     const query = SQL`SELECT COUNT(*) > 0 AS is_blacklisted
       FROM user_blacklist WHERE user_id = ${userId}
         AND (guild_id = ${guildId} OR is_global = true);`;
-    const res = await this.db.query(query);
-    if (res[0]) {
-      return res[0][0].is_blacklisted === '1';
+    const rows = await this.query(query);
+    if (rows) {
+      return rows[0].is_blacklisted === '1';
     }
     return false;
   }
@@ -29,9 +29,9 @@ class BlacklistQueries {
       FROM user_blacklist
       WHERE guild_id = ${guildId}
         AND is_global = ${global};`;
-    const res = await this.db.query(query);
-    if (res[0]) {
-      return res[0]
+    const [rows] = await this.query(query);
+    if (rows) {
+      return rows
         .map(result => this.bot.client.users.cache.get(result.user_id))
         .filter(user => user);
     }
@@ -48,7 +48,7 @@ class BlacklistQueries {
   async addBlacklistedUser(userId, guildId, global) {
     const query = SQL`INSERT IGNORE INTO user_blacklist
       VALUES (${userId}, ${guildId || 0}, ${global});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -63,7 +63,7 @@ class BlacklistQueries {
       WHERE user_id = ${userId}
         AND is_global = ${global}
         AND guild_id = ${guildId};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 }
 

--- a/src/settings/DatabaseQueries/CustomCommandQueries.js
+++ b/src/settings/DatabaseQueries/CustomCommandQueries.js
@@ -10,7 +10,7 @@ class CustomCommandQueries {
 
   async getCustomCommands() {
     const query = SQL`SELECT * FROM custom_commands WHERE (guild_id >> 22) % ${this.bot.shardTotal} in (${this.bot.shards})`;
-    const res = await this.db.query(query);
+    const res = await this.query(query);
     if (res[0]) {
       return res[0]
         .map(value => new CustomCommand(this.bot, value.command, value.response, value.guild_id));
@@ -22,10 +22,10 @@ class CustomCommandQueries {
     const id = `${call}${guild.id}`;
     const query = SQL`SELECT * FROM custom_commands WHERE guild_id = ${guild.id} AND command_id = ${id}`;
 
-    const res = await this.db.query(query);
-    if (res[0]) {
-      const vals = res[0]
-        .map(value => ({ call: value.command, response: value.response, id: value.command_id }));
+    const [rows] = await this.query(query);
+    if (rows) {
+      const vals = rows
+        .map(row => ({ call: row.command, response: row.response, id: row.command_id }));
       this.logger.warn(JSON.stringify(vals));
       return vals[0];
     }
@@ -34,7 +34,7 @@ class CustomCommandQueries {
 
   async updateCustomCommand(guild, { call, response, id }) {
     const newId = `${call}${guild.id}`;
-    return this.db.query(SQL`
+    return this.query(SQL`
       UPDATE custom_commands
       SET command_id = ${newId},
         command = ${call},
@@ -46,10 +46,10 @@ class CustomCommandQueries {
 
   async getCustomCommandsForGuild(guild) {
     const query = SQL`SELECT * FROM custom_commands WHERE guild_id = ${guild.id}`;
-    const res = await this.db.query(query);
-    if (res[0]) {
-      return res[0]
-        .map(value => new CustomCommand(this.bot, value.command, value.response, value.guild_id));
+    const [rows] = await this.query(query);
+    if (rows) {
+      return rows
+        .map(row => new CustomCommand(this.bot, row.command, row.response, row.guild_id));
     }
     return [];
   }
@@ -58,18 +58,18 @@ class CustomCommandQueries {
     const id = `${call}${message.guild.id}`;
     const query = SQL`INSERT INTO custom_commands (command_id, guild_id, command, response, creator_id)
       VALUES (${id}, ${message.guild.id}, ${call}, ${response}, ${message.author.id})`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async deleteCustomCommand(message, call) {
     const id = `${call}${message.guild.id}`;
     const query = SQL`DELETE FROM custom_commands WHERE command_id = ${id}`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async removeGuildCustomCommands(guildId) {
     const query = SQL`DELETE FROM custom_commands WHERE guild_id = ${guildId}`;
-    return this.db.query(query);
+    return this.query(query);
   }
 }
 

--- a/src/settings/DatabaseQueries/DBMQueries.js
+++ b/src/settings/DatabaseQueries/DBMQueries.js
@@ -15,7 +15,7 @@ class DBMQueries {
    */
   createSchema() {
     try {
-      return Promise.mapSeries(schema, q => this.db.query(q));
+      return Promise.mapSeries(schema, q => this.query(q));
     } catch (e) {
       this.logger.fatal(e);
       return undefined;
@@ -51,7 +51,7 @@ class DBMQueries {
         query.append(SQL`(${id}, ${guild.id})`).append(index !== (channelIDs.length - 1) ? ',' : ';');
       });
 
-      return this.db.query(query);
+      return this.query(query);
     }
     return undefined;
   }
@@ -63,7 +63,7 @@ class DBMQueries {
    */
   async addGuildTextChannel(channel) {
     const query = SQL`INSERT IGNORE INTO channels (id, guild_id) VALUES (${channel.id}, ${channel.guild.id});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -73,7 +73,7 @@ class DBMQueries {
    */
   async addDMChannel(channel) {
     const query = SQL`INSERT IGNORE INTO channels (id) VALUES (${channel.id});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -83,7 +83,7 @@ class DBMQueries {
    */
   async deleteChannel(channel) {
     const query = SQL`DELETE FROM channels WHERE id = ${channel.id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -93,7 +93,7 @@ class DBMQueries {
    */
   async removeGuild(guild) {
     const query = SQL`DELETE FROM channels WHERE guild_id = ${guild.id}`;
-    await this.db.query(query);
+    await this.query(query);
     const channelIds = guild.channels.keyArray();
     const results = [];
     channelIds.forEach((channelId) => {

--- a/src/settings/DatabaseQueries/PromocodeQueries.js
+++ b/src/settings/DatabaseQueries/PromocodeQueries.js
@@ -12,97 +12,97 @@ class PromocodeQueries {
       (pool_id, pool_name, pool_owner, pool_type, pool_default_guild)
       VALUES
       (${id}, ${name}, ${ownerId}, ${type || 'glyph'}, ${guild.id});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async deletePool(id) {
-    return this.db.query(SQL`DELETE FROM code_pool WHERE pool_id = ${id}`);
+    return this.query(SQL`DELETE FROM code_pool WHERE pool_id = ${id}`);
   }
 
   async setPoolName(id, name) {
     const query = SQL`UPDATE code_pool SET pool_name = ${name} WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async setPoolPassword(id, password) {
     const query = SQL`UPDATE code_pool SET pool_password = ${password} WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async setPoolType(id, type) {
     const query = SQL`UPDATE code_pool SET pool_type = ${type} WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async clearPoolPassword(id) {
     const query = SQL`UPDATE code_pool SET pool_password = NULL WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async restrictPool(id, status) {
     const query = SQL`UPDATE code_pool SET pool_restricted = ${status} WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async isPoolRestricted(id) {
     const query = SQL`SELECT pool_restricted FROM code_pool WHERE pool_id = ${id};`;
-    const res = await this.db.query(query);
-    if (res[0].length === 0) {
+    const [rows] = await this.query(query);
+    if (!rows.length) {
       return undefined;
     }
-    return res[0].pool_restricted;
+    return rows[0].pool_restricted;
   }
 
   async hasCodeInPool(member, pool) {
     const query = SQL`SELECT count(cm.code) as count
       FROM code_pool_member cm
       WHERE granted_to = ${member.id} and pool_id = ${pool};`;
-    const res = await this.db.query(query);
-    if (res[0].length === 0) {
+    const [rows] = await this.query(query);
+    if (!rows.length) {
       return undefined;
     }
-    return res[0].count > 0;
+    return rows.count > 0;
   }
 
   async isPoolPublic(id) {
     const query = SQL`SELECT pool_public FROM code_pool WHERE pool_id = ${id};`;
-    const res = await this.db.query(query);
-    if (res[0].length === 0) {
+    const rows = await this.query(query);
+    if (!rows.length) {
       return undefined;
     }
-    return res[0].pool_public;
+    return rows.pool_public;
   }
 
   async setPoolGuild(id, guildId) {
     const query = SQL`UPDATE code_pool SET pool_default_guild = ${guildId} WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async setPoolPublic(id, status) {
     const query = SQL`UPDATE code_pool SET pool_public = ${status} WHERE pool_id = ${id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async addPoolManager(id, manager) {
     const query = SQL`INSERT IGNORE INTO code_pool_manager VALUES (${id}, ${manager});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async addPoolManagers(id, newManagers) {
     const query = SQL`INSERT IGNORE INTO code_pool_manager VALUES ?;`;
     query.values = newManagers.map(manager => ([id, manager]));
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async removePoolManager(id, manager) {
     const query = SQL`DELETE FROM code_pool_manager WHERE pool_id = ${id} AND pool_manager = ${manager}`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async removePoolManagers(id, removeManagers) {
     const query = SQL`DELETE FROM code_pool_manager WHERE pool_id = ${id} AND pool_manager in (?)`;
     query.values = removeManagers;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async addCode(id, platform, adder, grantedTo, grantedBy, code) {
@@ -121,16 +121,14 @@ class PromocodeQueries {
 
   async getCode(code) {
     const query = SQL`SELECT * FROM code_pool_member WHERE code = ${code};`;
-    return (await this.db.query(query))[0];
+    return (await this.query(query))[0];
   }
 
   async getCodesInPools(poolIds) {
     const query = SQL`SELECT * from code_pool_member WHERE pool_id in (${poolIds})`;
-    const res = await this.db.query(query);
-    let codes = [];
-    if (res[0]) {
-      this.logger.debug(JSON.stringify(res[0]));
-      codes = res[0].map(row => ({
+    const [rows] = await this.query(query);
+    if (rows) {
+      return rows.map(row => ({
         id: row.pool_id,
         platform: row.platform,
         addedBy: row.added_by || null,
@@ -141,7 +139,7 @@ class PromocodeQueries {
         code: row.code,
       }));
     }
-    return codes;
+    return [];
   }
 
   async grantCode(code, grantedTo, grantedBy, platform) {
@@ -151,7 +149,7 @@ class PromocodeQueries {
         granted_on = NOW()
       WHERE code=${code}
         AND platform=${platform};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async revokeCode(code, poolId) {
@@ -161,7 +159,7 @@ class PromocodeQueries {
         granted_on = NULL
       WHERE code = ${code}
         AND pool_id = ${poolId};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async getNextCodeInPool(platform, pool) {
@@ -181,11 +179,11 @@ class PromocodeQueries {
         AND p.pool_id = m.pool_id
         AND (m.granted_to IS NULL OR m.granted_to = ${any})
       ORDER BY m.added_on LIMIT 1;`;
-    const res = await this.db.query(query);
-    if (res[0].length === 0) {
+    const [rows] = await this.query(query);
+    if (!rows.length) {
       return undefined;
     }
-    return res[0];
+    return rows;
   }
 
   async addCodes(codes) {
@@ -201,7 +199,7 @@ class PromocodeQueries {
       code.code,
     ]);
     query.values = [val];
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async getPoolsUserManages(user) {
@@ -215,37 +213,34 @@ class PromocodeQueries {
         ON (code_pool_member.pool_id = code_pool_manager.pool_id)
       WHERE code_pool_manager.pool_manager = ${user.id}
       GROUP BY code_pool_manager.pool_id;`;
-    const res = await this.db.query(query);
+    const [rows] = await this.query(query);
 
-    if (!(res && res[0]) || res[0].length === 0) {
+    if (!rows.length) {
       return [];
     }
-    return res[0];
+    return rows;
   }
 
   async userManagesPool(user, pool) {
     const query = SQL`SELECT pool_id FROM code_pool_manager WHERE pool_manager = ${user.id} AND pool_id = ${pool}`;
-    const res = await this.db.query(query);
-    if (res[0].length === 0) {
-      return false;
-    }
-    return true;
+    const [rows] = await this.query(query);
+    return rows.length;
   }
 
   async getGuildsPool(guild) {
     const query = SQL`SELECT pool_id FROM code_pool WHERE pool_default_guild = ${guild.id};`;
-    const res = await this.db.query(query);
-    if (res[0].length === 0) {
+    const [rows] = await this.query(query);
+    if (!rows.length) {
       return [];
     }
-    return res[0][0];
+    return rows[0];
   }
 
   async getUserCodes(user) {
     const query = SQL`SELECT p.pool_name, m.platform, m.code
       FROM code_pool_member as m, code_pool as p
       WHERE m.granted_to = ${user.id} and m.pool_id = p.pool_id;`;
-    return (await this.db.query(query))[0];
+    return (await this.query(query))[0];
   }
 }
 

--- a/src/settings/DatabaseQueries/RatioQuieries.js
+++ b/src/settings/DatabaseQueries/RatioQuieries.js
@@ -9,16 +9,16 @@ class RatioQueries {
 
   addGuildRatio(shard, guild) {
     if (!shard) return undefined;
-    return this.db.query(SQL`INSERT IGNORE INTO guild_ratio (shard_id, guild_id, owner_id) VALUES (${shard.id}, ${guild.id}, ${guild.ownerID});`);
+    return this.query(SQL`INSERT IGNORE INTO guild_ratio (shard_id, guild_id, owner_id) VALUES (${shard.id}, ${guild.id}, ${guild.ownerID});`);
   }
 
   getGuildRatios(shards) {
     if (!shards || !shards.length) return undefined;
-    return this.db.query(SQL`SELECT * FROM guild_ratio WHERE shard_id in (${shards});`);
+    return this.query(SQL`SELECT * FROM guild_ratio WHERE shard_id in (${shards});`);
   }
 
   deleteGuildRatio(guild) {
-    return this.db.query(SQL`DELETE FROM guild_ratio WHERE guild_id = ${guild.id};`);
+    return this.query(SQL`DELETE FROM guild_ratio WHERE guild_id = ${guild.id};`);
   }
 }
 

--- a/src/settings/DatabaseQueries/StatisticsQueries.js
+++ b/src/settings/DatabaseQueries/StatisticsQueries.js
@@ -8,7 +8,7 @@ class StatisticsQueries {
   }
 
   async trackRole(guild, channel, role) {
-    return this.db.query(SQL`
+    return this.query(SQL`
       INSERT IGNORE INTO role_stats
       (guild_id, channel_id, role_id)
       VALUES (${guild.id}, ${channel.id}, ${role.id})
@@ -16,7 +16,7 @@ class StatisticsQueries {
   }
 
   async untrackRole(guild, role) {
-    return this.db.query(SQL`
+    return this.query(SQL`
       DELETE FROM role_stats
       WHERE guild_id = ${guild.id}
         AND role_id = ${role.id}
@@ -26,7 +26,7 @@ class StatisticsQueries {
   async getTrackedRoles(guild) {
     const q = SQL`SELECT role_id, channel_id FROM role_stats WHERE guild_id = ${guild.id}`;
     const map = {};
-    const res = (await this.db.query(q))[0];
+    const res = (await this.query(q))[0];
     res.forEach(({ role_id: roleId, channel_id: channelId }) => {
       map[roleId] = channelId;
     });

--- a/src/settings/DatabaseQueries/StreamQueries.js
+++ b/src/settings/DatabaseQueries/StreamQueries.js
@@ -14,12 +14,12 @@ class RatioQueries {
     } else {
       q = SQL`INSERT IGNORE INTO streams (type, stream_name) (${type}, ${username})`;
     }
-    return this.db.query(q);
+    return this.query(q);
   }
 
   deleteStream(type, uid) {
     const q = SQL`DELETE FROM streams WHERE type = ${type} AND uid = ${uid}`;
-    return this.db.query(q);
+    return this.query(q);
   }
 
   async getTrackedStreams(shardIds, type, shardTotal) {
@@ -30,7 +30,7 @@ class RatioQueries {
       .append(SQL` INNER JOIN channels ON channels.id = types.channel_id
           AND MOD(IFNULL(channels.guild_id, 0) >> 22, ${shardTotal}) in (${shardIds})`);
 
-    return (await this.db.query(q))[0];
+    return (await this.query(q))[0];
   }
 }
 

--- a/src/settings/DatabaseQueries/TrackingQueries.js
+++ b/src/settings/DatabaseQueries/TrackingQueries.js
@@ -15,7 +15,7 @@ class TrackingQueries {
    */
   async trackItem(channel, item) {
     const query = SQL`INSERT IGNORE INTO item_notifications (channel_id, item) VALUES (${channel.id},${item});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -29,7 +29,7 @@ class TrackingQueries {
     items.forEach((item, index) => {
       query.append(SQL`(${channel.id}, ${item})`).append(index !== (items.length - 1) ? ',' : ';');
     });
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -40,7 +40,7 @@ class TrackingQueries {
    */
   async untrackItem(channel, item) {
     const query = SQL`DELETE FROM item_notifications WHERE channel_id = ${channel.id} AND item = ${item};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -55,7 +55,7 @@ class TrackingQueries {
       query.append(index > 0 ? '  OR ' : '').append(SQL`item = ${item}`);
     });
     query.append(SQL`);`);
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -66,7 +66,7 @@ class TrackingQueries {
    */
   async trackEventType(channel, type) {
     const query = SQL`INSERT IGNORE INTO type_notifications (channel_id, type) VALUES (${channel.id},${type});`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -82,7 +82,7 @@ class TrackingQueries {
         query.append(SQL`(${channel.id}, ${type})`).append(index !== (types.length - 1) ? ',' : ';');
       }
     });
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -93,7 +93,7 @@ class TrackingQueries {
    */
   async untrackEventType(channel, type) {
     const query = SQL`DELETE FROM type_notifications WHERE channel_id = ${channel.id} AND type = ${type};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -108,7 +108,7 @@ class TrackingQueries {
       query.append(index > 0 ? '  OR ' : '').append(SQL`type = ${type}`);
     });
     query.append(SQL`);`);
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -118,7 +118,7 @@ class TrackingQueries {
    */
   async getTrackedItems(channel) {
     const query = SQL`SELECT item FROM item_notifications WHERE channel_id = ${channel.id};`;
-    const res = await this.db.query(query);
+    const res = await this.query(query);
     return res[0].map(r => r.item);
   }
 
@@ -129,8 +129,8 @@ class TrackingQueries {
    */
   async getTrackedEventTypes(channel) {
     const query = SQL`SELECT type FROM type_notifications WHERE channel_id = ${channel.id};`;
-    const res = await this.db.query(query);
-    return res[0].map(r => r.type);
+    const [rows] = await this.query(query);
+    return rows.map(r => r.type);
   }
 
   /**
@@ -140,7 +140,7 @@ class TrackingQueries {
    */
   async removeItemNotifications(channelId) {
     const query = SQL`DELETE FROM item_notifications WHERE channel_id = ${channelId}`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -150,7 +150,7 @@ class TrackingQueries {
    */
   async removeTypeNotifications(channelId) {
     const query = SQL`DELETE FROM type_notifications WHERE channel_id = ${channelId}`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -160,7 +160,7 @@ class TrackingQueries {
    */
   async stopTracking(channel) {
     const query = SQL`DELETE FROM type_notifications WHERE channel_id = ${channel.id};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 }
 

--- a/src/settings/DatabaseQueries/WelcomeQueries.js
+++ b/src/settings/DatabaseQueries/WelcomeQueries.js
@@ -15,7 +15,7 @@ class WelcomeQueries {
    */
   async clearWelcomeForGuild(guild, isDm) {
     const query = SQL`DELETE FROM welcome_messages WHERE guild_id=${guild.id} && is_dm=${isDm}`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   /**
@@ -28,15 +28,15 @@ class WelcomeQueries {
   async setWelcome(message, isDm, text) {
     const query = SQL`INSERT INTO welcome_messages (guild_id, is_dm, channel_id, message) VALUES (${message.guild.id}, ${isDm}, ${message.channel.id}, ${text})
       ON DUPLICATE KEY UPDATE message = ${text};`;
-    return this.db.query(query);
+    return this.query(query);
   }
 
   async getWelcomes(guild) {
     if (guild) {
       const query = SQL`SELECT * FROM welcome_messages WHERE guild_id=${guild.id}`;
-      const res = await this.db.query(query);
-      if (res[0]) {
-        return res[0].map(value => ({
+      const [rows] = await this.query(query);
+      if (rows) {
+        return rows.map(value => ({
           isDm: value.is_dm,
           message: value.message,
           channel: this.bot.client.channels.cache.get(value.channel_id),


### PR DESCRIPTION
**Summary:**
Abstract out the query call, that way if it's called from a different package in the future, that can be handled in query instead of in each query method

Also uplift the destructuring pattern for the return object from the query method, as it returns `[rows, fields]`, and we were handing this either by checking `result[0]` or trying to dig deeper, which caused a lot of confusion.

Allows for using caching from an external source in the future, but the current mysql-cache project isn't up-to-date enough to use alongside/replacing mysql2 yet

---
**Resolves issue:**
N/A

---
**Screenshots:**
N/A