### PR TITLE
feat: support channel on settings get

### DIFF
--- a/src/interactions/core/Settings.js
+++ b/src/interactions/core/Settings.js
@@ -256,6 +256,7 @@ export default class Settings extends Interaction {
     ]);
 
     page.setTitle('General Settings');
+    page.setDescription(`<#${channel.id}>`);
     page.addFields([
       {
         name: 'Language',
@@ -439,6 +440,13 @@ export default class Settings extends Interaction {
       {
         ...cmds['settings.get'],
         type: Types.SUB_COMMAND,
+        options: [
+          {
+            ...cmds['settings.get.channel'],
+            type: Types.CHANNEL,
+            required: false,
+          },
+        ],
       },
       {
         ...cmds['settings.diag'],
@@ -474,7 +482,7 @@ export default class Settings extends Interaction {
     if (field === 'auto_text') value = !value;
 
     const isThread = interaction.channel.isThread();
-    const channel = isThread ? interaction.channel.parent : interaction.channel;
+    const channel = options?.getChannel('channel') ?? (isThread ? interaction.channel.parent : interaction.channel);
     const thread = isThread ? interaction.channel : undefined;
 
     switch (action) {

--- a/src/resources/locales/commands/cs.js
+++ b/src/resources/locales/commands/cs.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/de.js
+++ b/src/resources/locales/commands/de.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel'
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/en.js
+++ b/src/resources/locales/commands/en.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings',
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild',

--- a/src/resources/locales/commands/es.js
+++ b/src/resources/locales/commands/es.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Obtener todos los ajustes'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Debe ser un canal de texto'
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Ejecutar diagnóstico para el gremio'

--- a/src/resources/locales/commands/fr.js
+++ b/src/resources/locales/commands/fr.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/it.js
+++ b/src/resources/locales/commands/it.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/ko.js
+++ b/src/resources/locales/commands/ko.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/pl.js
+++ b/src/resources/locales/commands/pl.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/pt.js
+++ b/src/resources/locales/commands/pt.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel',
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/ru.js
+++ b/src/resources/locales/commands/ru.js
@@ -287,6 +287,10 @@ export default {
     name: 'запросить',
     description: 'Показывает все настройки'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel'
+  },
   'settings.diag': {
     name: 'диагностика',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/sr.js
+++ b/src/resources/locales/commands/sr.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel'
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/tr.js
+++ b/src/resources/locales/commands/tr.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel'
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/uk.js
+++ b/src/resources/locales/commands/uk.js
@@ -287,6 +287,10 @@ export default {
     name: 'отримати',
     description: 'Показує всі налаштування'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel'
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'

--- a/src/resources/locales/commands/zh.js
+++ b/src/resources/locales/commands/zh.js
@@ -287,6 +287,10 @@ export default {
     name: 'get',
     description: 'Get all the settings'
   },
+  'settings.get.channel': {
+    name: 'channel',
+    description: 'Should be a text channel'
+  },
   'settings.diag': {
     name: 'diag',
     description: 'Run diagnostics for the guild'


### PR DESCRIPTION
**Summary:**

---
**Resolves issue:**
resolves request from sphirical

---
**Screenshots:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional channel selection to the "settings.get" command, allowing users to specify which channel's settings to view.
  - The settings display now clearly indicates the channel being referenced.

- **Documentation**
  - Updated command descriptions for the new channel option in all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->